### PR TITLE
Remove forms references from overview repo

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -174,10 +174,10 @@ All github settings should be the same across all EDPub repositories. Developers
    EDPub framework. All other repos will follow include versions of the high level
    *.md files from there, e.g. CONTRIBUTING.md. The core repo is <https://github.com/eosdis-nasa/earthdata-pub>
 1. Repositories - EDPub repositories shall be named `earthdata-pub-thing`,
-   for example: `earthdata-pub-forms`, `earthdata-pub-api`.
+   for example: `earthdata-pub-dashboard`, `earthdata-pub-api`.
 1. Modules - EDPub core modules will be named "EDPub Thing" where "Thing" is
    always capitalized and one word. The name should be descriptive. Examples are
-   "EDPub Forms", "EDPub API", "EDPub Dashboard", "EDPub Workflows". It is acceptable
+   "EDPub API", "EDPub Dashboard", "EDPub Workflows". It is acceptable
    to use Thing as a name by itself when the context is obvious. So, Dashboard as
    a label inside an EDPub diagram makes sense.
 1. Abbreviation - We will use the abbreviation "EDPub" to shorten EDPub, however

--- a/package.json
+++ b/package.json
@@ -24,10 +24,8 @@
     "stop-api": "cd ../earthdata-pub-api && npm run stop",
     "start-dashboard": "cd ../earthdata-pub-dashboard && npm run start-dashboard",
     "stop-dashboard": "cd ../earthdata-pub-dashboard && npm run stop-dashboard",
-    "start-forms-dev": "cd ../earthdata-pub-forms && npm run start-forms-dev",
-    "stop-forms-dev": "cd ../earthdata-pub-forms && npm run stop-forms-dev",
-    "start-dev": "npm run start-api && npm run start-dashboard && npm run start-forms-dev && npm run start-overview-dev",
-    "stop-dev": "npm run stop-api && npm run stop-dashboard && npm run stop-forms-dev && npm run stop-overview-dev"
+    "start-dev": "npm run start-api && npm run start-dashboard && npm run start-overview-dev",
+    "stop-dev": "npm run stop-api && npm run stop-dashboard && npm run stop-overview-dev"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Remove forms references from overview repo to ensure no confusion on current integration status and unnecessary resource deployments